### PR TITLE
Fix emoji shortcode reference link

### DIFF
--- a/frontend/src/extensions/essential-app-extensions/emoji/emoji-app-extension.ts
+++ b/frontend/src/extensions/essential-app-extensions/emoji/emoji-app-extension.ts
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2023 The HedgeDoc developers (see AUTHORS file)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import type { CheatsheetExtension } from '../../../components/cheatsheet/cheatsheet-extension'
+import { regexCompletion } from '../../../components/editor-page/editor-pane/autocompletions/regex-completion'
+import type { MarkdownRendererExtension } from '../../../components/markdown-renderer/extensions/_base-classes/markdown-renderer-extension'
+import { AppExtension } from '../../_base-classes/app-extension'
+import { EmojiMarkdownRendererExtension } from './emoji-markdown-renderer-extension'
+import { emojiShortcodes } from './mapping'
+import type { CompletionSource } from '@codemirror/autocomplete'
+import { t } from 'i18next'
+
+export class EmojiAppExtension extends AppExtension {
+  buildMarkdownRendererExtensions(): MarkdownRendererExtension[] {
+    return [new EmojiMarkdownRendererExtension()]
+  }
+
+  buildCheatsheetExtensions(): CheatsheetExtension[] {
+    return [
+      {
+        i18nKey: 'emoji',
+        categoryI18nKey: 'other',
+        readMoreUrl: new URL('https://github.com/ikatyang/emoji-cheat-sheet/blob/master/README.md')
+      }
+    ]
+  }
+
+  buildAutocompletion(): CompletionSource[] {
+    const completions = [
+      {
+        detail: '',
+        label: ':'
+      },
+      ...emojiShortcodes.map((shortcode) => ({
+        detail: t('editor.autocompletions.emoji') ?? undefined,
+        label: `:${shortcode}:`
+      }))
+    ]
+    return [regexCompletion(/:(?:[\w-+]+:?)?/, completions)]
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes issue #4998 by updating the emoji shortcode reference link in the cheatsheet.

The previous link pointed to Twemoji (https://twemoji.twitter.com/), which doesn't provide shortcode information. This was confusing for users because the shortcodes shown on that site don't match the ones that work in HedgeDoc.

I've updated the link to point to the GitHub emoji cheat sheet (https://github.com/ikatyang/emoji-cheat-sheet/blob/master/README.md), which provides the correct GitHub-style shortcodes that HedgeDoc uses.

## Steps

- [x] Updated the `readMoreUrl` in the `EmojiAppExtension` class to point to the GitHub emoji cheat sheet
- [x] Verified that the new link provides the correct shortcodes that work in HedgeDoc

## Related Issue
Fixes hedgedoc/hedgedoc#4998

Solved with Zencoder